### PR TITLE
Node is now preinstalled in the base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,18 +6,6 @@ FROM bitriseio/docker-android:latest
 RUN apt-get update -qq
 
 # ------------------------------------------------------
-# --- Node JS
-
-# Node JS
-# Add the Node.js-maintained repositories to Ubuntu package source list
-RUN curl -sL https://deb.nodesource.com/setup_5.x | bash -
-# The nodejs package contains the nodejs binary as well as npm
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
-# "build-essential" required, but were pre-installed in base image
-RUN nodejs -v
-RUN npm -v
-
-# ------------------------------------------------------
 # --- Cordova CLI
 
 RUN npm install -g cordova


### PR DESCRIPTION
Unless you need Node v5, NodeJS (v6 right now) is preinstalled in the base image (https://github.com/bitrise-docker/bitrise-base/blob/master/Dockerfile#L81)